### PR TITLE
fix: resolve GELF hostname at adapter creation, not package init

### DIFF
--- a/adapters/gelf/gelf.go
+++ b/adapters/gelf/gelf.go
@@ -15,27 +15,28 @@ import (
 	"github.com/gliderlabs/logspout/router"
 )
 
-var hostname string
-
+// getHostname resolves the GELF source hostname. It must be called when an
+// adapter is created (NewGelfAdapter) rather than at package init: the Home
+// Assistant launcher sets SYSLOG_HOSTNAME inside main(), which runs after all
+// package init() functions, so reading it at init time would always miss the
+// configured value and fall back to the default below.
 func getHostname() string {
 	content, err := os.ReadFile("/etc/host_hostname")
 	if err == nil && len(content) > 0 {
-		hostname = strings.TrimRight(string(content), "\r\n")
-	} else {
-		hostname = cfg.GetEnvDefault("SYSLOG_HOSTNAME", "{{.Container.Config.Hostname}}")
+		return strings.TrimRight(string(content), "\r\n")
 	}
-	return hostname
+	return cfg.GetEnvDefault("SYSLOG_HOSTNAME", "{{.Container.Config.Hostname}}")
 }
 
 func init() {
-	hostname = getHostname()
 	router.AdapterFactories.Register(NewGelfAdapter, "gelf")
 }
 
 // Adapter is an adapter that streams UDP JSON to Graylog
 type Adapter struct {
-	writer gelf.Writer
-	route  *router.Route
+	writer   gelf.Writer
+	route    *router.Route
+	hostname string
 }
 
 // NewGelfAdapter creates an Adapter with UDP as the default transport.
@@ -46,8 +47,9 @@ func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
 
 	return &Adapter{
-		route:  route,
-		writer: gelfWriter,
+		route:    route,
+		writer:   gelfWriter,
+		hostname: getHostname(),
 	}, nil
 }
 
@@ -84,7 +86,7 @@ func (a *Adapter) Stream(logstream chan *router.Message) {
 
 		msg := gelf.Message{
 			Version:  "1.1",
-			Host:     hostname,
+			Host:     a.hostname,
 			Short:    m.Data,
 			TimeUnix: float64(m.Time.UnixNano()/int64(time.Millisecond)) / 1000.0,
 			Level:    int32(level),

--- a/adapters/gelf/gelf_test.go
+++ b/adapters/gelf/gelf_test.go
@@ -188,3 +188,46 @@ func TestGelfNewAdapterUnknownTransport(t *testing.T) {
 		t.Error("expected error for unknown transport, got nil")
 	}
 }
+
+// TestGelfAdapterResolvesHostnameAtCreation is the regression test for the
+// init-order bug. The Home Assistant launcher sets SYSLOG_HOSTNAME inside
+// main(), which Go runs AFTER every package init(). Resolving the hostname in
+// init() (the old behavior) froze it to the "{{.Container.Config.Hostname}}"
+// default before the launcher could set the configured value, so that literal
+// template string was shipped as the GELF source. The adapter must read
+// SYSLOG_HOSTNAME when it is created instead.
+func TestGelfAdapterResolvesHostnameAtCreation(t *testing.T) {
+	t.Setenv("SYSLOG_HOSTNAME", "myhost.example.com")
+
+	route := &router.Route{Address: "127.0.0.1:12201"} // default udp transport
+	adapter, err := NewGelfAdapter(route)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := adapter.(*Adapter).hostname
+	if got != "myhost.example.com" {
+		t.Fatalf("expected hostname resolved from SYSLOG_HOSTNAME at creation, got %q", got)
+	}
+}
+
+// TestGelfStreamUsesAdapterHostname verifies the per-adapter hostname is stamped
+// on every emitted message's Host (the GELF source) field.
+func TestGelfStreamUsesAdapterHostname(t *testing.T) {
+	mock := &mockGelfWriter{}
+	adapter := &Adapter{writer: mock, hostname: "myhost.example.com"}
+
+	streamAndWait(adapter, &router.Message{
+		Container: newTestContainer(),
+		Data:      "hello world",
+		Source:    "stdout",
+		Time:      time.Now(),
+	})
+
+	if len(mock.messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(mock.messages))
+	}
+	if mock.messages[0].Host != "myhost.example.com" {
+		t.Errorf("expected Host='myhost.example.com', got '%s'", mock.messages[0].Host)
+	}
+}


### PR DESCRIPTION
# fix: resolve GELF hostname at adapter creation, not package init

## Summary

Since the native Home Assistant launcher was introduced (the change that
"directly launch[es] logspout and parse[s] the config from there instead of
using a shell wrapper", HA app **v1.12.0**), the GELF adapter ships the literal,
unrendered string **`{{.Container.Config.Hostname}}`** as the message `host`
(Graylog **source**) field, ignoring the configured `hostname` option.

This breaks any downstream tooling that filters by `source` (e.g. Graylog
searches/streams scoped to a host), because every container from the host now
shares the bogus source `{{.Container.Config.Hostname}}` instead of the
configured value.

## Root cause: Go package-init ordering

`adapters/gelf/gelf.go` resolved the hostname in **package `init()`** and cached
it in a package global:

```go
var hostname string

func init() {
    hostname = getHostname()                 // reads SYSLOG_HOSTNAME / /etc/host_hostname
    router.AdapterFactories.Register(NewGelfAdapter, "gelf")
}
// ...
msg := gelf.Message{ /* ... */ Host: hostname }
```

The native launcher sets `SYSLOG_HOSTNAME` from the addon config **inside
`main()`** (`launcher.BuildEnvironment` → `os.Setenv`). Go runs **every package
`init()` before `main()`**, and `cmd/launcher` imports the adapters
transitively (`modules` → `adapters/gelf`). So the ordering is:

1. `gelf.init()` runs → `SYSLOG_HOSTNAME` is still unset and `/etc/host_hostname`
   is absent → the global is frozen to the fallback default
   `"{{.Container.Config.Hostname}}"`.
2. `main()` → `launcher.Run()` → `os.Setenv("SYSLOG_HOSTNAME", <configured>)` —
   too late; the global was already set.
3. `Stream()` stamps the frozen literal on every message.

It worked **before** the native launcher because the old shell wrapper exported
`SYSLOG_HOSTNAME` and then `exec`'d logspout as a **separate process**, so the
environment was already in place when `init()` ran. Moving the launcher
in-process exposed the latent init-time read.

(The default value `"{{.Container.Config.Hostname}}"` is a Go `text/template`
that the upstream adapter this is "based on"
[micahhausler/logspout-gelf](https://github.com/micahhausler/logspout-gelf)
renders per message; this fork uses it as a raw string. That's why the *literal*
template text appears rather than a rendered hostname.)

## Fix

Resolve the hostname when the adapter is **created** (`NewGelfAdapter`, invoked
by `runner.Run` *after* the launcher has populated the environment) and store it
on the `Adapter`, instead of reading it in `init()`:

```go
func getHostname() string {
    if content, err := os.ReadFile("/etc/host_hostname"); err == nil && len(content) > 0 {
        return strings.TrimRight(string(content), "\r\n")
    }
    return cfg.GetEnvDefault("SYSLOG_HOSTNAME", "{{.Container.Config.Hostname}}")
}

func init() {
    router.AdapterFactories.Register(NewGelfAdapter, "gelf")
}

type Adapter struct {
    writer   gelf.Writer
    route    *router.Route
    hostname string
}

func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
    w, err := gelfWriter(route)
    if err != nil {
        return nil, err
    }
    return &Adapter{route: route, writer: w, hostname: getHostname()}, nil
}
// Stream(): Host: a.hostname
```

The launcher always sets `SYSLOG_HOSTNAME` (defaulting to `homeassistant` when
the option is empty), so the template-default branch is no longer reached in the
addon; the configured `hostname` now reaches Graylog as the source again.

## Tests

Added two tests in `adapters/gelf/gelf_test.go`:

- **`TestGelfAdapterResolvesHostnameAtCreation`** — sets `SYSLOG_HOSTNAME`
  *after* package init (simulating the launcher) and asserts `NewGelfAdapter`
  resolves it. This fails against the old init-time read and is the direct
  regression guard.
- **`TestGelfStreamUsesAdapterHostname`** — asserts the per-adapter hostname is
  stamped on each emitted message's `Host`.

`go test ./adapters/gelf/ ./launcher/` passes; `go build ./cmd/launcher`
succeeds; `gofmt` clean.

## Optional follow-up (not in this PR)

To make the `{{.Container.Config.Hostname}}` default behave as intended for
non-addon users, render `hostname` as a `text/template` against each
`router.Message` (restoring the upstream micahhausler behavior). Happy to add
this if desired.